### PR TITLE
Separate RIPEstat client from enricher, implement concurrency

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,14 +31,17 @@ func init() {
 func main() {
 
 	options := Options{}
-	goflags := flags.NewParser(&options,
-		flags.Default)
+	goflags := flags.NewParser(&options, flags.Default)
 
 	parser := parser.Parser{}
 
 	_, err := goflags.Parse()
 	if err != nil {
-		logrus.Fatal("Error parsing flags")
+		if errFlags, ok := err.(*flags.Error); ok && errFlags.Type == flags.ErrHelp {
+			// flags automatically prints usage
+			os.Exit(0)
+		}
+		logrus.Fatalf("Error parsing flags: %v", err)
 	}
 
 	if noOutputProvided := options.Output == ""; noOutputProvided {

--- a/pkg/enricher/main.go
+++ b/pkg/enricher/main.go
@@ -21,6 +21,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var (
+	whoisRegexp = regexp.MustCompile("[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*")
+)
+
 type Enricher struct {
 	types.EnrichInfo
 	ripeStatSourceApp string
@@ -126,7 +130,6 @@ func (e *Enricher) Enrich() *types.EnrichInfo {
 func (e *Enricher) whoisEnrichment() []string {
 	logrus.Debug("enricher: ripestat has no abuse mails for us, executing whoisEnrichment on e.Ip: ", e.Ip)
 
-	re := regexp.MustCompile("[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*")
 	abusemails := []string{}
 
 	whois, err := whois.Whois(e.Ip)
@@ -136,7 +139,7 @@ func (e *Enricher) whoisEnrichment() []string {
 		return []string{}
 	}
 
-	abusemails = append(abusemails, re.FindAllString(whois, -1)...)
+	abusemails = append(abusemails, whoisRegexp.FindAllString(whois, -1)...)
 
 	if len(abusemails) == 0 {
 		logrus.Debug("enricher: whoisEnrichment - could not find any abuse emails for ", e.Ip)

--- a/pkg/enricher/main.go
+++ b/pkg/enricher/main.go
@@ -103,24 +103,16 @@ func (e *Enricher) enrichPrefixAndASNFromIP(ipAddr string) (string, string) {
 func (e *Enricher) enrichHolderFromASN(asn string) string {
 	holder := "unknown"
 
-	// Get ASN info from ripeStat - https://stat.ripe.net/data/as-overview/data.json?resource=
 	if asn == "unknown" {
 		return holder
 	}
 
-	asn_data, err := e.queryRipeStat("as-overview", asn)
+	asOverview, err := e.rs.GetASOverview(asn)
 	if err != nil {
 		return holder
 	}
 
-	if asn_data["data"] != nil {
-		asn_datablock := asn_data["data"].(map[string]interface{})
-		if asn_datablock["holder"] != nil {
-			holder = asn_datablock["holder"].(string)
-		}
-	}
-
-	return holder
+	return asOverview.Holder
 }
 
 func (e *Enricher) enrichCityAndCountryFromPrefix(prefix string) (string, string) {

--- a/pkg/enricher/main.go
+++ b/pkg/enricher/main.go
@@ -25,9 +25,12 @@ var (
 	whoisRegexp = regexp.MustCompile("[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*")
 )
 
+const (
+	ripeStatSourceApp = "AS50559-DIVD_NL"
+)
+
 type Enricher struct {
 	types.EnrichInfo
-	ripeStatSourceApp string
 }
 
 func NewEnricher(ip string) *Enricher {
@@ -35,134 +38,179 @@ func NewEnricher(ip string) *Enricher {
 		EnrichInfo: types.EnrichInfo{
 			Ip: ip,
 		},
-		ripeStatSourceApp: "AS50559-DIVD_NL",
 	}
 }
 
 func (e *Enricher) Enrich() *types.EnrichInfo {
+	return e.EnrichIP(e.Ip)
+}
+
+func (e *Enricher) EnrichIP(ipAddr string) *types.EnrichInfo {
 	e.EnrichInfo = types.EnrichInfo{
-		Ip:           e.Ip,
-		Abuse_source: "",
-		Abuse:        "unknown",
-		Country:      "unknown",
-		City:         "unknown",
-		Holder:       "unknown",
+		Ip: ipAddr,
 	}
 
-	// Get abuse info - https://stat.ripe.net/data/abuse-contact-finder/data.<format>?<parameters>
-	ripestat_abuse_reply, err := e.queryRipeStat("abuse-contact-finder", e.Ip)
-	if err == nil {
-		abuse_contacts_ripeStat := []string{}
+	e.EnrichInfo.Abuse, e.EnrichInfo.Abuse_source = e.enrichAbuseFromIP(ipAddr)
+	e.EnrichInfo.Prefix, e.EnrichInfo.Asn = e.enrichPrefixAndASNFromIP(ipAddr)
+	e.EnrichInfo.Holder = e.enrichHolderFromASN(e.EnrichInfo.Asn)
+	e.EnrichInfo.City, e.EnrichInfo.Country = e.enrichCityAndCountryFromPrefix(e.EnrichInfo.Prefix)
 
-		if ripestat_abuse_reply != nil {
-			abuse_reply_data := ripestat_abuse_reply["data"].(map[string]interface{})
-			if abuse_reply_data != nil {
-				abuse_reply_data_abuse_contacts := abuse_reply_data["abuse_contacts"].([]interface{})
-
-				for _, abuse_contact := range abuse_reply_data_abuse_contacts {
-					abuse_contacts_ripeStat = append(abuse_contacts_ripeStat, abuse_contact.(string))
-				}
-			}
-		}
-
-		if len(abuse_contacts_ripeStat) > 0 {
-			e.EnrichInfo.Abuse = strings.Join(abuse_contacts_ripeStat, ";")
-			e.EnrichInfo.Abuse_source = "ripeSTAT"
-		} else {
-			contacts_from_whois := e.whoisEnrichment()
-			if len(contacts_from_whois) > 0 {
-				e.EnrichInfo.Abuse = strings.Join(contacts_from_whois, ";")
-				e.EnrichInfo.Abuse_source = "whois"
-			}
-		}
-
-		// Get ASN - https://stat.ripe.net/data/network-info/data.json?resource=
-		asn_reply, err := e.queryRipeStat("network-info", e.Ip)
-		if err == nil {
-			asn_reply_data := asn_reply["data"].(map[string]interface{})
-
-			if asn_reply_data["prefix"] != nil {
-				e.EnrichInfo.Prefix = asn_reply_data["prefix"].(string)
-			}
-
-			if asn_reply_data["asns"] != nil {
-				asn_reply_data_asn := asn_reply_data["asns"].([]interface{})
-				if len(asn_reply_data_asn) > 0 {
-					e.EnrichInfo.Asn = asn_reply_data_asn[0].(string)
-				}
-			}
-		}
-
-		// Get ASN info from ripeStat - https://stat.ripe.net/data/as-overview/data.json?resource=
-		if e.EnrichInfo.Asn != "unknown" {
-			asn_data, err := e.queryRipeStat("as-overview", e.EnrichInfo.Asn)
-			if err == nil {
-				if asn_data["data"] != nil {
-					asn_datablock := asn_data["data"].(map[string]interface{})
-					if asn_datablock["holder"] != nil {
-						e.EnrichInfo.Holder = asn_datablock["holder"].(string)
-					}
-				}
-			}
-
-			// Get geolocation from RipeStat - https://stat.ripe.net/data/geoloc/data.json?resource=
-			if e.EnrichInfo.Prefix != "unknown" {
-				location_data, err := e.queryRipeStat("maxmind-geo-lite", e.EnrichInfo.Prefix)
-				if err == nil {
-					if location_data["data"] != nil {
-						location_data_located_resources := location_data["data"].(map[string]interface{})["located_resources"].([]interface{})
-						if len(location_data_located_resources) > 0 {
-							location_data_located_resources_locations := location_data_located_resources[0].(map[string]interface{})["locations"].([]interface{})
-							if len(location_data_located_resources_locations) > 0 {
-								location_data_located_resources_location := location_data_located_resources_locations[0].(map[string]interface{})
-								e.EnrichInfo.City = location_data_located_resources_location["city"].(string)
-								e.EnrichInfo.Country = location_data_located_resources_location["country"].(string)
-							}
-						}
-					}
-				}
-			}
-		}
-	}
 	return &e.EnrichInfo
 }
 
+func (e *Enricher) enrichAbuseFromIP(ipAddr string) (string, string) {
+	abuse := "unknown"
+	abuseSource := ""
+
+	// Get abuse info - https://stat.ripe.net/data/abuse-contact-finder/data.<format>?<parameters>
+	ripestat_abuse_reply, err := e.queryRipeStat("abuse-contact-finder", ipAddr)
+	if err != nil {
+		return abuse, abuseSource
+	}
+
+	abuse_contacts_ripeStat := []string{}
+
+	if ripestat_abuse_reply != nil {
+		abuse_reply_data := ripestat_abuse_reply["data"].(map[string]interface{})
+		if abuse_reply_data != nil {
+			abuse_reply_data_abuse_contacts := abuse_reply_data["abuse_contacts"].([]interface{})
+
+			for _, abuse_contact := range abuse_reply_data_abuse_contacts {
+				abuse_contacts_ripeStat = append(abuse_contacts_ripeStat, abuse_contact.(string))
+			}
+		}
+	}
+
+	if len(abuse_contacts_ripeStat) > 0 {
+		return strings.Join(abuse_contacts_ripeStat, ";"), "ripeSTAT"
+	}
+
+	// Fallback to whois
+	contacts_from_whois := e.whoisEnrichment()
+	if len(contacts_from_whois) > 0 {
+		return strings.Join(contacts_from_whois, ";"), "whois"
+	}
+
+	return abuse, abuseSource
+}
+
+func (e *Enricher) enrichPrefixAndASNFromIP(ipAddr string) (string, string) {
+	prefix := "unknown"
+	asn := "unknown"
+
+	// Get ASN - https://stat.ripe.net/data/network-info/data.json?resource=
+	asn_reply, err := e.queryRipeStat("network-info", ipAddr)
+	if err != nil {
+		return prefix, asn
+	}
+
+	asn_reply_data := asn_reply["data"].(map[string]interface{})
+
+	if replyPrefix, ok := asn_reply_data["prefix"]; ok {
+		prefix = replyPrefix.(string)
+	}
+
+	if asns, ok := asn_reply_data["asns"]; ok {
+		asn_reply_data_asn := asns.([]interface{})
+		if len(asn_reply_data_asn) > 0 {
+			asn = asn_reply_data_asn[0].(string)
+		}
+	}
+
+	return prefix, asn
+}
+
+func (e *Enricher) enrichHolderFromASN(asn string) string {
+	holder := "unknown"
+
+	// Get ASN info from ripeStat - https://stat.ripe.net/data/as-overview/data.json?resource=
+	if asn == "unknown" {
+		return holder
+	}
+
+	asn_data, err := e.queryRipeStat("as-overview", asn)
+	if err != nil {
+		return holder
+	}
+
+	if asn_data["data"] != nil {
+		asn_datablock := asn_data["data"].(map[string]interface{})
+		if asn_datablock["holder"] != nil {
+			holder = asn_datablock["holder"].(string)
+		}
+	}
+
+	return holder
+}
+
+func (e *Enricher) enrichCityAndCountryFromPrefix(prefix string) (string, string) {
+	city := "unknown"
+	country := "unknown"
+
+	if prefix == "unknown" {
+		return city, country
+	}
+
+	location_data, err := e.queryRipeStat("maxmind-geo-lite", prefix)
+	if err != nil {
+		return city, country
+	}
+
+	if location_data["data"] != nil {
+		location_data_located_resources := location_data["data"].(map[string]interface{})["located_resources"].([]interface{})
+		if len(location_data_located_resources) > 0 {
+			location_data_located_resources_locations := location_data_located_resources[0].(map[string]interface{})["locations"].([]interface{})
+			if len(location_data_located_resources_locations) > 0 {
+				location_data_located_resources_location := location_data_located_resources_locations[0].(map[string]interface{})
+				city = location_data_located_resources_location["city"].(string)
+				country = location_data_located_resources_location["country"].(string)
+			}
+		}
+	}
+
+	return city, country
+}
+
 func (e *Enricher) whoisEnrichment() []string {
-	logrus.Debug("enricher: ripestat has no abuse mails for us, executing whoisEnrichment on e.Ip: ", e.Ip)
+	return e.whoisEnrichmentIP(e.Ip)
+}
 
-	abusemails := []string{}
+func (e *Enricher) whoisEnrichmentIP(ipAddr string) []string {
+	logrus.Debug("enricher: ripestat has no abuse mails for us, executing whoisEnrichment on IP address: ", ipAddr)
 
-	whois, err := whois.Whois(e.Ip)
-
-	if err != nil || whois == "" {
-		logrus.Debug("enricher: whoisEnrichment - could not get whois info for ", e.Ip)
+	whoisInfo, err := whois.Whois(ipAddr)
+	if err != nil || whoisInfo == "" {
+		logrus.Debug("enricher: whoisEnrichment - could not get whois info for ", ipAddr)
 		return []string{}
 	}
 
-	abusemails = append(abusemails, whoisRegexp.FindAllString(whois, -1)...)
-
-	if len(abusemails) == 0 {
-		logrus.Debug("enricher: whoisEnrichment - could not find any abuse emails for ", e.Ip)
+	foundMailAddresses := whoisRegexp.FindAllString(whoisInfo, -1)
+	switch len(foundMailAddresses) {
+	case 0:
+		logrus.Debug("enricher: whoisEnrichment - could not find any abuse emails for ", ipAddr)
+		return []string{}
+	case 1:
+		// Spare some allocations and a sort if there's only one address found
+		return []string{strings.ToLower(foundMailAddresses[0])}
 	}
 
 	// lower and sort unique
-	func() {
-		m := make(map[string]bool)
-		for _, v := range abusemails {
-			m[strings.ToLower(v)] = true
-		}
-		abusemails = make([]string, 0, len(m))
-		for k := range m {
-			abusemails = append(abusemails, k)
-		}
-		sort.Strings(abusemails)
-	}()
+	m := make(map[string]struct{}, len(foundMailAddresses))
+	for _, v := range foundMailAddresses {
+		m[strings.ToLower(v)] = struct{}{}
+	}
+
+	abusemails := make([]string, 0, len(m))
+	for k := range m {
+		abusemails = append(abusemails, k)
+	}
+	sort.Strings(abusemails)
 
 	return abusemails
 }
 
 func (e *Enricher) queryRipeStat(resource string, query string) (map[string]interface{}, error) {
-	url := fmt.Sprintf("https://stat.ripe.net/data/%s/data.json?resource=%s&sourceapp=%s", resource, query, e.ripeStatSourceApp)
+	url := fmt.Sprintf("https://stat.ripe.net/data/%s/data.json?resource=%s&sourceapp=%s", resource, query, ripeStatSourceApp)
 
 	resp, err := http.Get(url)
 	if err != nil {
@@ -170,6 +218,7 @@ func (e *Enricher) queryRipeStat(resource string, query string) (map[string]inte
 		return nil, err
 	}
 	defer resp.Body.Close()
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		logrus.Debug("enricher: queryRipeStat - could not read response body from ", url)

--- a/pkg/enricher/main.go
+++ b/pkg/enricher/main.go
@@ -210,6 +210,9 @@ func (e *Enricher) whoisEnrichmentIP(ipAddr string) []string {
 }
 
 func (e *Enricher) queryRipeStat(resource string, query string) (map[string]interface{}, error) {
+	if query == "" {
+		return nil, fmt.Errorf("empty query for resource %v", resource)
+	}
 	url := fmt.Sprintf("https://stat.ripe.net/data/%s/data.json?resource=%s&sourceapp=%s", resource, query, ripeStatSourceApp)
 
 	resp, err := http.Get(url)

--- a/pkg/enricher/main.go
+++ b/pkg/enricher/main.go
@@ -31,7 +31,7 @@ type Enricher struct {
 
 func NewEnricher() *Enricher {
 	return &Enricher{
-		rs: ripestat.NewRipeStatClient(ripeStatSourceApp),
+		rs: ripestat.NewRipeStatClient(ripeStatSourceApp, 10),
 	}
 }
 

--- a/pkg/enricher/main.go
+++ b/pkg/enricher/main.go
@@ -88,26 +88,16 @@ func (e *Enricher) enrichPrefixAndASNFromIP(ipAddr string) (string, string) {
 	prefix := "unknown"
 	asn := "unknown"
 
-	// Get ASN - https://stat.ripe.net/data/network-info/data.json?resource=
-	asn_reply, err := e.queryRipeStat("network-info", ipAddr)
+	netInfo, err := e.rs.GetNetworkInfo(ipAddr)
 	if err != nil {
 		return prefix, asn
 	}
 
-	asn_reply_data := asn_reply["data"].(map[string]interface{})
-
-	if replyPrefix, ok := asn_reply_data["prefix"]; ok {
-		prefix = replyPrefix.(string)
+	if len(netInfo.ASNs) == 0 {
+		return netInfo.Prefix, asn
 	}
 
-	if asns, ok := asn_reply_data["asns"]; ok {
-		asn_reply_data_asn := asns.([]interface{})
-		if len(asn_reply_data_asn) > 0 {
-			asn = asn_reply_data_asn[0].(string)
-		}
-	}
-
-	return prefix, asn
+	return netInfo.Prefix, netInfo.ASNs[0]
 }
 
 func (e *Enricher) enrichHolderFromASN(asn string) string {

--- a/pkg/parser/main.go
+++ b/pkg/parser/main.go
@@ -56,11 +56,11 @@ func (p *Parser) EnrichScanRecords() {
 		}
 		ipAddrs[record.Ip] = struct{}{}
 	}
+	enricher := enricher.NewEnricher()
 	for ipAddr := range ipAddrs {
-		enricher := enricher.NewEnricher(ipAddr)
-		enricher.Enrich()
+		info := enricher.EnrichIP(ipAddr)
 
-		p.Enrichment = append(p.Enrichment, enricher.EnrichInfo)
+		p.Enrichment = append(p.Enrichment, info)
 	}
 }
 

--- a/pkg/parser/main.go
+++ b/pkg/parser/main.go
@@ -48,8 +48,16 @@ func (p *Parser) ProcessNucleiScan() {
 }
 
 func (p *Parser) EnrichScanRecords() {
-	for _, record := range p.ScanRecords {
-		enricher := enricher.NewEnricher(record.Ip)
+	ipAddrs := make(map[string]struct{})
+	for i, record := range p.ScanRecords {
+		if record.Ip == "" {
+			logrus.Warnf("scan record %d contains empty IP address, skipping: %+v", i, record)
+			continue
+		}
+		ipAddrs[record.Ip] = struct{}{}
+	}
+	for ipAddr := range ipAddrs {
+		enricher := enricher.NewEnricher(ipAddr)
 		enricher.Enrich()
 
 		p.Enrichment = append(p.Enrichment, enricher.EnrichInfo)
@@ -68,7 +76,7 @@ func (p *Parser) MergeScanEnrichment() {
 
 	for _, record := range p.ScanRecords {
 		for _, enrichment := range p.Enrichment {
-			if ok := record.Ip == enrichment.Ip; ok {
+			if record.Ip == enrichment.Ip {
 				mergeResult.EnrichInfo = enrichment
 				mergeResult.NucleiJsonRecord = record
 				p.MergeResults = append(p.MergeResults, mergeResult)
@@ -82,7 +90,7 @@ func (p *Parser) MergeScanEnrichment() {
 func (p *Parser) WriteOutput(outputFile *os.File) {
 	logrus.Debug("parser: WriteOutput - start")
 
-	flattened := make(map[string]interface{})
+	flattened := make(map[string]types.MergeResult)
 	for _, mergeResult := range p.MergeResults {
 		flattened[mergeResult.EnrichInfo.Ip] = mergeResult
 	}

--- a/pkg/ripestat/client.go
+++ b/pkg/ripestat/client.go
@@ -36,6 +36,14 @@ func (c *Client) GetNetworkInfo(ipAddr string) (NetworkInfo, error) {
 	return ConvertNetworkInfoData(data)
 }
 
+func (c *Client) GetASOverview(asn string) (ASOverview, error) {
+	data, err := c.sendRequest("as-overview", asn)
+	if err != nil {
+		return ASOverview{}, err
+	}
+	return ConvertASOverviewData(data)
+}
+
 func (c *Client) sendRequest(endpoint, resource string) ([]byte, error) {
 	endpoint = url.QueryEscape(endpoint)
 	resource = url.QueryEscape(resource)

--- a/pkg/ripestat/client.go
+++ b/pkg/ripestat/client.go
@@ -44,6 +44,14 @@ func (c *Client) GetASOverview(asn string) (ASOverview, error) {
 	return ConvertASOverviewData(data)
 }
 
+func (c *Client) GetGeolocationData(prefix string) (MaxmindGeoLite, error) {
+	data, err := c.sendRequest("maxmind-geo-lite", prefix)
+	if err != nil {
+		return MaxmindGeoLite{}, err
+	}
+	return ConvertGeolocationData(data)
+}
+
 func (c *Client) sendRequest(endpoint, resource string) ([]byte, error) {
 	endpoint = url.QueryEscape(endpoint)
 	resource = url.QueryEscape(resource)

--- a/pkg/ripestat/client.go
+++ b/pkg/ripestat/client.go
@@ -1,0 +1,48 @@
+package ripestat
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+)
+
+const (
+	DATA_URL = "https://stat.ripe.net/data/"
+)
+
+type Client struct {
+	SourceApp string
+}
+
+func NewRipeStatClient(sourceApp string) *Client {
+	return &Client{
+		SourceApp: sourceApp,
+	}
+}
+
+func (c *Client) GetAbuseContacts(ipAddr string) ([]string, error) {
+	data, err := c.sendRequest("abuse-contact-finder", ipAddr)
+	if err != nil {
+		return nil, err
+	}
+	return ConvertAbuseContactsData(data)
+}
+
+func (c *Client) sendRequest(endpoint, resource string) ([]byte, error) {
+	endpoint = url.QueryEscape(endpoint)
+	resource = url.QueryEscape(resource)
+	url := DATA_URL + endpoint + "/data.json?resource=" + resource + "&sourceapp=" + c.SourceApp
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}

--- a/pkg/ripestat/client.go
+++ b/pkg/ripestat/client.go
@@ -28,6 +28,14 @@ func (c *Client) GetAbuseContacts(ipAddr string) ([]string, error) {
 	return ConvertAbuseContactsData(data)
 }
 
+func (c *Client) GetNetworkInfo(ipAddr string) (NetworkInfo, error) {
+	data, err := c.sendRequest("network-info", ipAddr)
+	if err != nil {
+		return NetworkInfo{}, err
+	}
+	return ConvertNetworkInfoData(data)
+}
+
 func (c *Client) sendRequest(endpoint, resource string) ([]byte, error) {
 	endpoint = url.QueryEscape(endpoint)
 	resource = url.QueryEscape(resource)

--- a/pkg/ripestat/converters.go
+++ b/pkg/ripestat/converters.go
@@ -30,3 +30,16 @@ func ConvertNetworkInfoData(data []byte) (NetworkInfo, error) {
 	}
 	return resp.Data, nil
 }
+
+func ConvertASOverviewData(data []byte) (ASOverview, error) {
+	if len(data) == 0 {
+		return ASOverview{}, fmt.Errorf("empty data")
+	}
+
+	resp := ASOverviewBase{}
+	err := json.Unmarshal(data, &resp)
+	if err != nil {
+		return ASOverview{}, err
+	}
+	return resp.Data, nil
+}

--- a/pkg/ripestat/converters.go
+++ b/pkg/ripestat/converters.go
@@ -43,3 +43,16 @@ func ConvertASOverviewData(data []byte) (ASOverview, error) {
 	}
 	return resp.Data, nil
 }
+
+func ConvertGeolocationData(data []byte) (MaxmindGeoLite, error) {
+	if len(data) == 0 {
+		return MaxmindGeoLite{}, fmt.Errorf("empty data")
+	}
+
+	resp := MaxmindGeoLiteBase{}
+	err := json.Unmarshal(data, &resp)
+	if err != nil {
+		return MaxmindGeoLite{}, err
+	}
+	return resp.Data, nil
+}

--- a/pkg/ripestat/converters.go
+++ b/pkg/ripestat/converters.go
@@ -1,0 +1,19 @@
+package ripestat
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func ConvertAbuseContactsData(data []byte) ([]string, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty data")
+	}
+
+	resp := AbuseContactFinderBase{}
+	err := json.Unmarshal(data, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data.AbuseContacts, nil
+}

--- a/pkg/ripestat/converters.go
+++ b/pkg/ripestat/converters.go
@@ -17,3 +17,16 @@ func ConvertAbuseContactsData(data []byte) ([]string, error) {
 	}
 	return resp.Data.AbuseContacts, nil
 }
+
+func ConvertNetworkInfoData(data []byte) (NetworkInfo, error) {
+	if len(data) == 0 {
+		return NetworkInfo{}, fmt.Errorf("empty data")
+	}
+
+	resp := NetworkInfoBase{}
+	err := json.Unmarshal(data, &resp)
+	if err != nil {
+		return NetworkInfo{}, err
+	}
+	return resp.Data, nil
+}

--- a/pkg/ripestat/endpoints.go
+++ b/pkg/ripestat/endpoints.go
@@ -41,3 +41,24 @@ type NetworkInfo struct {
 	ASNs   []string `json:"asns"`
 	Prefix string   `json:"prefix"`
 }
+
+type ASOverviewBase struct {
+	ResponseBase
+	Data ASOverview `json:"data"`
+}
+
+type ASOverview struct {
+	Type           string  `json:"type"`
+	Resource       string  `json:"resource"`
+	Block          ASBlock `json:"block"`
+	Holder         string  `json:"holder"`
+	Announced      bool    `json:"announced"`
+	QueryStartTime string  `json:"query_starttime"`
+	QueryEndTime   string  `json:"query_endtime"`
+}
+
+type ASBlock struct {
+	Resource    string `json:"resource"`
+	Description string `json:"desc"`
+	Name        string `json:"name"`
+}

--- a/pkg/ripestat/endpoints.go
+++ b/pkg/ripestat/endpoints.go
@@ -62,3 +62,42 @@ type ASBlock struct {
 	Description string `json:"desc"`
 	Name        string `json:"name"`
 }
+
+type MaxmindGeoLiteBase struct {
+	ResponseBase
+	Data MaxmindGeoLite
+}
+
+type MaxmindGeoLite struct {
+	LocatedResources   []LocatedResource `json:"located_resources"`
+	UnknownPercentages UnknownPercentage `json:"unknown_percentage"`
+	Parameters         MaxmindParameters `json:"parameters"`
+	ResultTime         string            `json:"result_time"`
+	LatestTime         string            `json:"latest_time"`
+	EarliestTime       string            `json:"earliest_time"`
+}
+
+type LocatedResource struct {
+	Resource  string             `json:"resource"`
+	Locations []ResourceLocation `json:"locations"`
+}
+
+type ResourceLocation struct {
+	Country           string   `json:"country"`
+	City              string   `json:"city"`
+	Resources         []string `json:"resources"`
+	Latitude          float64  `json:"latitude"`  // XXX: another data type?
+	Longitude         float64  `json:"longitude"` // XXX: another data type?
+	CoveredPercentage float64  `json:"covered_percentage"`
+	UnknownPercentage float64  `json:"unknown_percentage"`
+}
+
+type UnknownPercentage struct {
+	V4 float64 `json:"v4"`
+	V6 float64 `json:"v6"`
+}
+
+type MaxmindParameters struct {
+	ParameterBase
+	Resolution string `json:"resolution"`
+}

--- a/pkg/ripestat/endpoints.go
+++ b/pkg/ripestat/endpoints.go
@@ -1,0 +1,33 @@
+package ripestat
+
+type ResponseBase struct {
+	Messages       []string `json:"messages"`
+	SeeAlso        []string `json:"see_also"`
+	DataCallName   string   `json:"data_call_name"`
+	DataCallStatus string   `json:"data_call_status"`
+	Cached         bool     `json:"cached"`
+	QueryID        string   `json:"query_id"`
+	ProcessTime    int      `json:"process_time"`
+	ServerID       string   `json:"server_id"`
+	BuildVersion   string   `json:"build_version"`
+	Status         string   `json:"status"`
+	StatusCode     int      `json:"status_code"`
+	Time           string   `json:"time"`
+}
+
+type ParameterBase struct {
+	Resource string `json:"resource"`
+}
+
+type AbuseContactFinderBase struct {
+	ResponseBase
+	Data AbuseContactFinder `json:"data"`
+}
+
+type AbuseContactFinder struct {
+	AbuseContacts    []string      `json:"abuse_contacts"`
+	AuthoritativeRIR string        `json:"authoritative_rir"`
+	LatestTime       string        `json:"latest_time"`
+	EarliestTime     string        `json:"earliest_time"`
+	Parameters       ParameterBase `json:"parameters"`
+}

--- a/pkg/ripestat/endpoints.go
+++ b/pkg/ripestat/endpoints.go
@@ -31,3 +31,13 @@ type AbuseContactFinder struct {
 	EarliestTime     string        `json:"earliest_time"`
 	Parameters       ParameterBase `json:"parameters"`
 }
+
+type NetworkInfoBase struct {
+	ResponseBase
+	Data NetworkInfo `json:"data"`
+}
+
+type NetworkInfo struct {
+	ASNs   []string `json:"asns"`
+	Prefix string   `json:"prefix"`
+}

--- a/pkg/types/main.go
+++ b/pkg/types/main.go
@@ -18,7 +18,7 @@ type NucleiJsonRecord struct {
 		Name        string   `json:"name"`
 		Author      []string `json:"author"`
 		Tags        []string `json:"tags"`
-		Reference   string   `json:"reference"`
+		Reference   []string `json:"reference"`
 		Severity    string   `json:"severity"`
 		Description string   `json:"description"`
 	} `json:"info"`


### PR DESCRIPTION
Note that this PR was branched off from #2.

It adds:

- a separate package that handles queries to RIPEstat
    - Retries (including exponential backoff and jitter) are optional, although currently set to maximum of 10 retries
- limited concurrency when enriching IP addresses