### PR TITLE
Change parser to print out duplicate ips, distinct it by vhost

### DIFF
--- a/pkg/parser/main.go
+++ b/pkg/parser/main.go
@@ -117,10 +117,6 @@ func (p *Parser) MergeScanEnrichment() {
 		}
 
 		for _, enrichment := range p.Enrichment {
-			if seen := seenHosts[record.Host]; seen {
-				continue
-			}
-
 			seenHosts[record.Host] = true
 
 			mergeResult.EnrichInfo = enrichment

--- a/pkg/parser/main.go
+++ b/pkg/parser/main.go
@@ -12,7 +12,6 @@ import (
 	"nuclei-parse-enrich/pkg/types"
 	"os"
 	"sync"
-	"time"
 
 	//"time"
 
@@ -88,7 +87,7 @@ func (p *Parser) EnrichScanRecords() {
 		ipAddr := record["ip"]
 		limitCh <- true // block if limit is reached
 		go func() {
-			logrus.Debug("scheduled: %v", time.Now())
+			//logrus.Debug("scheduled: %v", time.Now())
 			wg.Add(1) // gets marked as Done in resultCh loop
 			resultCh <- enricher.EnrichIP(ipAddr)
 			<-limitCh


### PR DESCRIPTION

Fixes missing records that contain a distinct IP address but were scanned with a separate virtual host; storing uniquely based on IP results results in losing virtual hosts and scan timestamps

this PR solves that by merging and processing every record for each IP, but keep the virtual host within a seen map. 